### PR TITLE
Trying to simplify getting the plugin up and running

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -2,9 +2,13 @@ SublimeLinter-jshint
 -------------------------------
 This linter plugin for SublimeLinter provides an interface to jshint.
 
-INSTALLATION
-------------
-Before this plugin will activate, you *must* follow the installation
-instructions here:
+-------------
+**IMPORTANT**
+-------------
+Before this plugin will activate, both SublimeLinter and jshint must be installed!
 
+To install SublimeLinter, use Package Control and search for 'sublimelinter'.
+To install jshint, use 'npm install -g jshint' (assuming Node is already installed)
+
+For more information, visit:
 https://github.com/SublimeLinter/SublimeLinter-jshint


### PR DESCRIPTION
After seeing multiple issues pop up on SublimeLinter about it not working only to find out they didn't have either the plugin installed or jshint installed, I thought maybe adding details in the actual popup would help mitigate this instead of making the user follow a url to the instructions.
