### PR TITLE
Do not match words for jshint

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -28,6 +28,7 @@ class JSHint(Linter):
         'html': 'source.js.embedded.html'
     }
     config_file = ('--config', '.jshintrc', '~')
+    word_re = ""
 
     def split_match(self, match):
         """


### PR DESCRIPTION
Think this works better for jshint. Currently it will match things like the end `)` in `function(unusedArg)` and the `3` in `if (5==3)` and the empty space after the unused variable foo: `var foo = 5;`

At least this works better when showing the errors in the popup and placing the cursor at the right column.

It will however not show errors highlighted inline, only in the gutter. Not sure if we can get both behaviours?
