### PR TITLE
Added special highlighting of unused, non strict comparison and ++/--

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -34,7 +34,7 @@ class JSHint(Linter):
         r'|(.+)?\'(?P<late_def>.+)\'.+(?=.+W003)'
         # double declaration
         r'|(.+)?\'(?P<double_declare>.+)\'.+(?=.+W004)'
-        # non strict operators
+        # unexpected use, typically use of non strict operators
         r'|.+\'(?P<actual>.+)\'\.(?=.+W116)'
         # unexpected use of ++ etc
         r'|.+\'(?P<unexpected>.+)\'\.(?=.+W016)'
@@ -73,30 +73,38 @@ class JSHint(Linter):
             if fail:
                 # match, line, col, error, warning, message, near
                 return match, 0, 0, True, False, fail, None
+
             # highlight variables used before defined
             elif code == '003':
                 col -= len(match.group('late_def'))
+
             # highlight double declared variables
             elif code == '004':
                 col -= len(match.group('double_declare'))
+
             # now jshint place the column in front,
             # and as such we need to change our word matching regex,
             # and keep the column info
             elif code == '016':
-                self.word_re = re.compile('\+\+|--')
+                self.word_re = re.compile(r'\+\+|--')
+
             # mark the duplicate key
             elif code == '075':
                 col -= len(match.group('duplicate'))
+
             # mark the undefined word
             elif code == '098':
                 col -= len(match.group('undef'))
+
             # mark the no camel case key, cannot use safer method of
             # subtracting the length of the match, as the original col info
             # from jshint is always column 0, using near instead
             elif code == '106':
                 near = match.group('no_camel')
                 col = None
+
             # if we have a operator == or != manually change the column,
+            # this also handles the warning when curly brackets are required
             # near won't work here as we might have multiple ==/!= on a line
             elif code == '116':
                 actual = match.group('actual')


### PR DESCRIPTION
As you suggested (#15) I took a stab at it, but instead of using near, which only matches the first word, and can cause problems with multiple occurrences of the word or symbols like ==/!= etc I modify the column information.

I am keeping the existing behaviour, but for the 3 cases it will provide a better highlighting.

This is how this implementation will look now on this example case: 
![highlight-2](https://f.cloud.github.com/assets/230877/1910004/97cd3ba6-7d0b-11e3-8768-7c0ae327e05e.png)

```
function unusedfunc() {}

function test(unusedarg) {
  var unused = { //missing use strict and unused
    extracomma:5, //extra comma
  };
  var anothervar = 5;
  if (5 == 4 && 5 == 3 && 4 != 5) {
    anothervar++;
    anothervar--;
  }


  with(window){
    return;
  }

  if(true){} //empty block
}

test() //missing semicolon
```

This was run with this jshintrc.

```
{
    "bitwise": true,
    "curly": false,
    "eqeqeq": true,
    "forin": false,
    "immed": true,
    "latedef": "nofunc",
    "newcap": true,
    "noarg": true,
    "noempty": true,
    "nonew": false,
    "plusplus": true,
    "regexp": false,
    "undef": true,
    "strict": true,
    "trailing": false,
    "asi": false,
    "boss": false,
    "debug": false,
    "eqnull": false,
    "es3": true,
    "esnext": false,
    "evil": false,
    "expr": false,
    "unused": true,
    "funcscope": false,
    "globalstrict": false,
    "iterator": false,
    "lastsemic": false,
    "laxbreak": false,
    "laxcomma": false,
    "loopfunc": false,
    "multistr": false,
    "onecase": false,
    "proto": false,
    "regexdash": false,
    "scripturl": false,
    "smarttabs": true,
    "shadow": false,
    "sub": false,
    "supernew": false,
    "validthis": true,
    "browser": true,
    "couch": false,
    "devel": false,
    "dojo": false,
    "jquery": false,
    "mootools": false,
    "node": false,
    "nonstandard": false,
    "prototypejs": false,
    "rhino": false,
    "wsh": false,
    "nomen": false,
    "onevar": true,
    "passfail": false,
    "white": false,
    "maxerr": 100
}
```
