### PR TITLE
Added support for JavaScriptNext syntax

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class JSHint(Linter):
 
     """Provides an interface to the jshint executable."""
 
-    syntax = ('javascript', 'html')
+    syntax = ('javascript', 'html', 'javascriptnext')
     executable = 'jshint'
     version_args = '--version'
     version_re = r'\bv(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
Hey guys,

I added support for the JavaScript Next syntax (https://github.com/Benvie/JavaScriptNext.tmLanguage) which enables jshint linting for this advanced JavaScript syntax. With this you are able to have SublimeLinter lint javascript files, while having namespaces, variables etc. recognized and highlighted by JavaScript Next.
If you are interested in supporting this syntax with the jshint linter, feel free to merge this pull request.

Cheers.
