### PR TITLE
Added tab_width to linter.py

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,6 +19,7 @@ class JSHint(Linter):
     """Provides an interface to the jshint executable."""
 
     syntax = ('javascript', 'html', 'javascriptnext')
+    tab_width = 4
     executable = 'jshint'
     version_args = '--version'
     version_re = r'\bv(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
Without tab_width=4:
![](http://i.imgur.com/m4EVPKq.png)
With:
![](http://i.imgur.com/KQXFaDL.png)

The reported col is still off because it gets reported at the = rather than the end of the variable's name for W004.
