### PR TITLE
Added support for syntax from the settings file.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,8 @@ from SublimeLinter.lint import persist
 class JSHint(Linter):
 
     """Provides an interface to the jshint executable."""
-    Linter.syntax_settings = persist.settings.get('jshint_syntax', [ "html", "laravel-blade", "javascript", "javascriptnext"])
+    default_list = ["html", "laravel-blade", "javascript", "javascriptnext"]
+    Linter.syntax_settings = persist.settings.get('jshint_syntax', default_list)
 
     syntax = (Linter.syntax_settings)
     executable = 'jshint'

--- a/linter.py
+++ b/linter.py
@@ -18,9 +18,10 @@ from SublimeLinter.lint import persist
 class JSHint(Linter):
 
     """Provides an interface to the jshint executable."""
+
     default_list = ["html", "laravel-blade", "javascript", "javascriptnext"]
     Linter.syntax_settings = persist.settings.get('jshint_syntax', default_list)
-    
+
     syntax = (Linter.syntax_settings)
     executable = 'jshint'
     version_args = '--version'

--- a/linter.py
+++ b/linter.py
@@ -16,11 +16,11 @@ from SublimeLinter.lint import persist
 
 
 class JSHint(Linter):
-    
+
     """Provides an interface to the jshint executable."""
     default_list = ["html", "laravel-blade", "javascript", "javascriptnext"]
     Linter.syntax_settings = persist.settings.get('jshint_syntax', default_list)
-
+    
     syntax = (Linter.syntax_settings)
     executable = 'jshint'
     version_args = '--version'

--- a/linter.py
+++ b/linter.py
@@ -16,7 +16,7 @@ from SublimeLinter.lint import persist
 
 
 class JSHint(Linter):
-
+    
     """Provides an interface to the jshint executable."""
     default_list = ["html", "laravel-blade", "javascript", "javascriptnext"]
     Linter.syntax_settings = persist.settings.get('jshint_syntax', default_list)

--- a/linter.py
+++ b/linter.py
@@ -12,13 +12,15 @@
 
 import re
 from SublimeLinter.lint import Linter
+from SublimeLinter.lint import persist
 
 
 class JSHint(Linter):
 
     """Provides an interface to the jshint executable."""
+    Linter.syntax_settings = persist.settings.get('jshint_syntax', [ "html", "laravel-blade", "javascript", "javascriptnext"])
 
-    syntax = ('javascript', 'html', 'javascriptnext')
+    syntax = (Linter.syntax_settings)
     executable = 'jshint'
     version_args = '--version'
     version_re = r'\bv(?P<version>\d+\.\d+\.\d+)'
@@ -52,7 +54,7 @@ class JSHint(Linter):
         """Return the command line to execute."""
         command = [self.executable_path, '--verbose', '--filename', '@']
 
-        if self.syntax == 'html':
+        if self.syntax in Linter.syntax_settings:
             command.append('--extract=always')
 
         return command + ['*', '-']


### PR DESCRIPTION
I use inline javascript in laravel blade or smarty files - jshint doesn't work when we use different syntax than "html" or "javascript". Now we can define syntax in settings.
