### PR TITLE
add 'javascript (babel)' as a syntax

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class JSHint(Linter):
 
     """Provides an interface to the jshint executable."""
 
-    syntax = ('javascript', 'html', 'javascriptnext')
+    syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)')
     executable = 'jshint'
     version_args = '--version'
     version_re = r'\bv(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
I have since upgraded to the new [Babel](https://github.com/babel/babel-sublime) package and found that this linter doesn't include support for the new syntax name.

I propose adding it the list of supported syntaxes as I don't want to have to move to the eslint plugin and support the `eslintrc` configuration file.
