### PR TITLE
Add possibility to use local JSHint package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Before installing this plugin, you must ensure that `jshint` is installed on you
    ```
    npm install -g jshint
    ```
+Or install `jshint` locally in your project folder (**you must have package.json file there**):
+    ```
+    npm init -f
+    npm install jshint
+    ```
 
 1. If you are using `nvm` and `zsh`, ensure that the line to load `nvm` is in `.zshenv` and not `.zshrc`.
 

--- a/linter.py
+++ b/linter.py
@@ -12,14 +12,16 @@
 """This module exports the JSHint plugin linter class."""
 
 import re
-from SublimeLinter.lint import Linter
+from SublimeLinter.lint import NodeLinter
 
 
-class JSHint(Linter):
+class JSHint(NodeLinter):
+
     """Provides an interface to the jshint executable."""
 
     syntax = ('javascript', 'html', 'javascriptnext')
-    executable = 'jshint'
+    npm_name = 'jshint'
+    cmd = ('jshint', '--verbose', '@')
     version_args = '--version'
     version_re = r'\bv(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 2.5.0'
@@ -46,16 +48,9 @@ class JSHint(Linter):
         # capture error, warning and code
         r' \((?:(?P<error>E)|(?P<warning>W))(?P<code>\d+)\))'
     )
-    config_file = ('--config', '.jshintrc', '~')
-
-    def cmd(self):
-        """Return the command line to execute."""
-        command = [self.executable_path, '--verbose', '--filename', '@']
-
-        if self.syntax == 'html':
-            command.append('--extract=always')
-
-        return command + ['*', '-']
+    selectors = {
+        'html': 'source.js.embedded.html'
+    }
 
     def split_match(self, match):
         """


### PR DESCRIPTION
This PR will make JSHint linter behave just like [ESLint version](https://github.com/roadhump/SublimeLinter-eslint) by using SublimeLinter’s `NodeLinter` which first looks for local version of linter, traversing up to global version.

This way you have option to only use local version of JSHint and keep your global namespace clean.

Notes:
- I’ve removed argument `--filename` since it wasn’t doing anything this way
- Extracting is provided via `selectors` hash map now, I suppose, haven’t tried it
