### PR TITLE
Explicitly restore `self.word_re` to `Linter.word_re`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -66,7 +66,7 @@ class JSHint(Linter):
 
         """
         # restore word regex to default each iteration
-        self.word_re = None
+        self.word_re = Linter.word_re
 
         if match:
             fail = match.group('fail')


### PR DESCRIPTION
SL4 changed the default here. So restoring to `None` isn't safe anymore.

DO NOT MERGE BEFORE https://github.com/SublimeLinter/SublimeLinter/pull/777 