### PR TITLE
Parse embedded js in html using the core SL functionality

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -47,15 +47,13 @@ class JSHint(Linter):
         r' \((?:(?P<error>E\d+)|(?P<warning>W\d+))\))'
     )
     config_file = ('--config', '.jshintrc', '~')
+    selectors = {
+        'html': 'source.js.embedded.html'
+    }
 
     def cmd(self):
         """Return the command line to execute."""
-        command = [self.executable_path, '--verbose', '--filename', '@']
-
-        if self.syntax == 'html':
-            command.append('--extract=always')
-
-        return command + ['*', '-']
+        return [self.executable_path, '--verbose', '--filename', '@', '*', '-']
 
     def split_match(self, match):
         """


### PR DESCRIPTION
jshint is broken when it has to read via stdin. Thus, we just use
the builtin selector based functionality that comes with SublimeLinter.

See https://github.com/SublimeLinter/SublimeLinter/issues/805#issuecomment-357542179

Fixes #87 
Fixes #106 